### PR TITLE
update tasks.py and celery till 5.0.0.1

### DIFF
--- a/Chapter07/myshop/orders/tasks.py
+++ b/Chapter07/myshop/orders/tasks.py
@@ -1,9 +1,9 @@
-from celery import task
+from celery import shared_task
 from django.core.mail import send_mail
 from .models import Order
 
 
-@task
+@shared_task
 def order_created(order_id):
     """
     Task to send an e-mail notification when an order is


### PR DESCRIPTION
Hi, found following mislead:
Followed by the book and found that celery '4.0.0.1' have import errors description here 'https://github.com/celery/kombu/issues/870'.
So I updated celery till 5.0.0.1 and found that can not import task get error of 'no module task'.
Go to documents of celery and found that task were updated and now are 'shared_task', documents : https://docs.celeryproject.org/en/stable/django/first-steps-with-django.html. Go to 'Using Celery with Django'.

Have a good day.