### PR TITLE
Update rounting.py for Channels v3

### DIFF
--- a/Chapter13/educa/chat/routing.py
+++ b/Chapter13/educa/chat/routing.py
@@ -2,5 +2,5 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-    re_path(r'ws/chat/room/(?P<course_id>\d+)/$', consumers.ChatConsumer),
+    re_path(r'ws/chat/room/(?P<course_id>\d+)/$', consumers.ChatConsumer.as_asgi()),
 ]


### PR DESCRIPTION
add as_asgi() classmethod to re_path. This is similar to Django’s as_view(), which plays the same role for per-request Django view instances.